### PR TITLE
fix logo scale #4

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -303,7 +303,7 @@ header {
       img {
         display: inline;
         height: 100%;
-        width: 100%;
+        width: auto;
       }
     }
 


### PR DESCRIPTION
The problem was that also the `img` width needs to be set to `width: auto;`.
